### PR TITLE
bump: make hashicorp/aws dependency less strict

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.34.0"
+      version = ">= 3.34.0"
     }
   }
 }


### PR DESCRIPTION
Provider version of hashicorp/aws ">= 3.34.0" rather than pin makes module more easily compatible with others.